### PR TITLE
OWIN adapter: Re-work response stream to not buffer.

### DIFF
--- a/src/Libraries/Microsoft.Http2.Protocol/Http2Stream.cs
+++ b/src/Libraries/Microsoft.Http2.Protocol/Http2Stream.cs
@@ -260,15 +260,15 @@ namespace Microsoft.Http2.Protocol
         /// </summary>
         /// <param name="data">The data.</param>
         /// <param name="isEndStream">if set to <c>true</c> [is fin].</param>
-        public void WriteDataFrame(byte[] data, bool isEndStream)
+        public void WriteDataFrame(ArraySegment<byte> data, bool isEndStream)
         {
-            if (data == null)
+            if (data.Array == null)
                 throw new ArgumentNullException("data is null");
 
             if (Disposed)
                 return;
 
-            var dataFrame = new DataFrame(_id, new ArraySegment<byte>(data), isEndStream);
+            var dataFrame = new DataFrame(_id, data, isEndStream);
 
             //We cant let lesser frame that were passed through flow control window
             //be sent before greater frames that were not passed through flow control window

--- a/src/Microsoft.Http2.Owin.Server/Adapters/Http11OwinMessageHandler.cs
+++ b/src/Microsoft.Http2.Owin.Server/Adapters/Http11OwinMessageHandler.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Http2.Owin.Server.Adapters
                 var path = splittedRequestString[1];
 
                 // main OWIN environment components
-                // OWIN request and reponse below shares the same environment dictionary instance
+                // OWIN request and response below shares the same environment dictionary instance
                 _environment = CreateOwinEnvironment(method, scheme, "", path, headers);
                 _request = new OwinRequest(_environment);
                 _response = new OwinResponse(_environment);

--- a/src/Microsoft.Http2.Owin.Server/Adapters/Http2OwinMessageContext.cs
+++ b/src/Microsoft.Http2.Owin.Server/Adapters/Http2OwinMessageContext.cs
@@ -1,0 +1,112 @@
+﻿using Microsoft.Http2.Protocol;
+using Microsoft.Http2.Protocol.IO;
+using Microsoft.Http2.Protocol.Utils;
+using Microsoft.Owin;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Http2.Owin.Server.Adapters
+{
+    // Tracks per-request state.
+    internal class Http2OwinMessageContext
+    {
+        private Http2Stream _protocolStream;
+        private IOwinContext _owinContext;
+        private IHeaderDictionary _responseHeaders;
+        private TransportInformation _transportInfo;
+        private bool _responseStarted = false;
+
+        internal Http2OwinMessageContext(Http2Stream protocolStream, TransportInformation transportInfo)
+        {
+            _protocolStream = protocolStream;
+            _transportInfo = transportInfo;
+            PopulateEnvironment();
+        }
+
+        internal IDictionary<string, object> Environment
+        {
+            get { return _owinContext.Environment; }
+        }
+
+        /// <summary>
+        /// Adopts protocol terms into owin environment.
+        /// </summary>
+        private void PopulateEnvironment()
+        {
+            HeadersList headers = _protocolStream.Headers;
+            _owinContext = new OwinContext();
+            _responseHeaders = _owinContext.Response.Headers;
+
+            var headersAsDict = headers.ToDictionary(header => header.Key, header => new[] { header.Value }, StringComparer.OrdinalIgnoreCase);
+            _owinContext.Environment[CommonOwinKeys.RequestHeaders] = headersAsDict;
+
+            var owinRequest = _owinContext.Request;
+            var owinResponse = _owinContext.Response;
+
+            owinRequest.Method = headers.GetValue(CommonHeaders.Method);
+            owinRequest.Path = headers.GetValue(CommonHeaders.Path);
+            owinRequest.CallCancelled = CancellationToken.None;
+
+            owinRequest.Host = headers.GetValue(CommonHeaders.Host);
+            owinRequest.PathBase = String.Empty;
+            owinRequest.QueryString = String.Empty;
+            owinRequest.Body = Stream.Null;
+            owinRequest.Protocol = Protocols.Http2;
+            owinRequest.Scheme = headers.GetValue(CommonHeaders.Scheme) == Uri.UriSchemeHttp ? Uri.UriSchemeHttp : Uri.UriSchemeHttps;
+            owinRequest.RemoteIpAddress = _transportInfo.RemoteIpAddress;
+            owinRequest.RemotePort = Convert.ToInt32(_transportInfo.RemotePort);
+            owinRequest.LocalIpAddress = _transportInfo.LocalIpAddress;
+            owinRequest.LocalPort = _transportInfo.LocalPort;
+
+            owinResponse.Body = new ResponseStream(_protocolStream, StartResponse);
+        }
+
+        private void StartResponse()
+        {
+            Debug.Assert(!_responseStarted, "Response started more than once");
+            _responseStarted = true;
+            IOwinResponse response = _owinContext.Response;
+            Http2Logger.LogDebug("Transfer begin");
+
+            SendHeaders(final: false);
+        }
+
+        // If no response headers have been sent yet, send them.
+        internal void FinishResponse()
+        {
+            if (!_responseStarted)
+            {
+                Http2Logger.LogDebug("Transfer begin");
+
+                SendHeaders(final: true);
+
+                Http2Logger.LogDebug("Transfer end");
+            }
+            else
+            {
+                // End the data stream.
+                _protocolStream.WriteDataFrame(new ArraySegment<byte>(new byte[0]), isEndStream: true);
+            }
+        }
+
+        /// <summary>
+        /// Writes the status header to the stream.
+        /// </summary>
+        /// <param name="stream">The stream.</param>
+        /// <param name="statusCode">The status code.</param>
+        /// <param name="final">if set to <c>true</c> then marks headers frame as final.</param>
+        /// <param name="additionalHeaders">The additional headers.</param>
+        private void SendHeaders(bool final)
+        {
+            HeadersList responseHeaders = new HeadersList(_responseHeaders);
+            responseHeaders.Add(new KeyValuePair<string, string>(CommonHeaders.Status, _owinContext.Response.StatusCode.ToString()));
+            _protocolStream.WriteHeadersFrame(responseHeaders, final, true);
+        }
+    }
+}

--- a/src/Microsoft.Http2.Owin.Server/Adapters/Http2OwinMessageHandler.cs
+++ b/src/Microsoft.Http2.Owin.Server/Adapters/Http2OwinMessageHandler.cs
@@ -41,43 +41,6 @@ namespace Microsoft.Http2.Owin.Server.Adapters
         }
 
         /// <summary>
-        /// Adopts protocol terms into owin environment.
-        /// </summary>
-        /// <param name="headers">The headers.</param>
-        /// <returns></returns>
-        private OwinContext PopulateEnvironment(HeadersList headers)
-        {
-            var owinContext = new OwinContext();
-
-            var headersAsDict = headers.ToDictionary(header => header.Key, header => new[] {header.Value}, StringComparer.OrdinalIgnoreCase);
-
-            owinContext.Environment[CommonOwinKeys.RequestHeaders] = headersAsDict;
-            owinContext.Environment[CommonOwinKeys.ResponseHeaders] = new Dictionary<string, string[]>();
-
-            var owinRequest = owinContext.Request;
-            var owinResponse = owinContext.Response;
-
-            owinRequest.Method = headers.GetValue(CommonHeaders.Method);
-            owinRequest.Path = headers.GetValue(CommonHeaders.Path);
-            owinRequest.CallCancelled = CancellationToken.None;
-
-            owinRequest.Host = headers.GetValue(CommonHeaders.Host);
-            owinRequest.PathBase = String.Empty;
-            owinRequest.QueryString = String.Empty;
-            owinRequest.Body = new MemoryStream();
-            owinRequest.Protocol = Protocols.Http2;
-            owinRequest.Scheme = headers.GetValue(CommonHeaders.Scheme) == Uri.UriSchemeHttp ? Uri.UriSchemeHttp : Uri.UriSchemeHttps;
-            owinRequest.RemoteIpAddress = _transportInfo.RemoteIpAddress;
-            owinRequest.RemotePort = Convert.ToInt32(_transportInfo.RemotePort);
-            owinRequest.LocalIpAddress = _transportInfo.LocalIpAddress;
-            owinRequest.LocalPort = _transportInfo.LocalPort;
-
-            owinResponse.Body = new ResponseStream{Capacity = 16384};
-
-            return owinContext;
-        }
-
-        /// <summary>
         /// Overrides request processing logic.
         /// </summary>
         /// <param name="stream">The stream.</param>
@@ -89,24 +52,24 @@ namespace Microsoft.Http2.Owin.Server.Adapters
             //8.1.2.1.  Request Header Fields
             //HTTP/2.0 defines a number of headers starting with a ':' character
             //that carry information about the request target:
- 
+
             //o  The ":method" header field includes the HTTP method ([HTTP-p2],
             //      Section 4).
- 
+
             //o  The ":scheme" header field includes the scheme portion of the
             //      target URI ([RFC3986], Section 3.1).
- 
+
             //o  The ":host" header field includes the authority portion of the
             //      target URI ([RFC3986], Section 3.2).
- 
+
             //o  The ":path" header field includes the path and query parts of the
-                //target URI (the "path-absolute" production from [RFC3986] and
-                 //optionally a '?' character followed by the "query" production, see
-                 //[RFC3986], Section 3.3 and [RFC3986], Section 3.4).  This field
-                 //MUST NOT be empty; URIs that do not contain a path component MUST
-                 //include a value of '/', unless the request is an OPTIONS request
-                 //for '*', in which case the ":path" header field MUST include '*'.
- 
+            //target URI (the "path-absolute" production from [RFC3986] and
+            //optionally a '?' character followed by the "query" production, see
+            //[RFC3986], Section 3.3 and [RFC3986], Section 3.4).  This field
+            //MUST NOT be empty; URIs that do not contain a path component MUST
+            //include a value of '/', unless the request is an OPTIONS request
+            //for '*', in which case the ":path" header field MUST include '*'.
+
             //All HTTP/2.0 requests MUST include exactly one valid value for all of
             //these header fields.  An intermediary MUST ensure that requests that
             //it forwards are correct.  A server MUST treat the absence of any of
@@ -123,77 +86,19 @@ namespace Microsoft.Http2.Owin.Server.Adapters
             }
 
             Task.Factory.StartNew(async () =>
-                {
-                    var context = PopulateEnvironment(stream.Headers);
-                    await SendResponse(stream, context);
-                });
-
-        }
-
-        private async Task SendResponse(Http2Stream stream, IOwinContext context)
-        {
-            try
             {
-                var isFirstWrite = true;
-                var response = context.Response;
-                var respBody = response.Body as ResponseStream;
-                HeadersList responseHeaders = null;
-
-                if (respBody == null)
+                try
                 {
-                    stream.WriteRst(ResetStatusCode.InternalError);
-                    return;
+                    var context = new Http2OwinMessageContext(stream, _transportInfo);
+                    await _next(context.Environment);
+                    context.FinishResponse();
                 }
-
-                int contentLen = 0;
-                int read = 0;
-
-                respBody.OnDataWritten += (sender, args) =>
-                    {
-                        if (isFirstWrite)
-                        {
-                            Http2Logger.LogDebug("Transfer begin");
-                            if (response.Headers != null)
-                            {
-                                responseHeaders = new HeadersList(response.Headers);
-                                contentLen = int.Parse(responseHeaders.GetValue(CommonHeaders.ContentLength));
-                            }
-                            WriteStatus(stream, response.StatusCode, response.StatusCode != StatusCode.Code200Ok, responseHeaders);
-                        }
-                        isFirstWrite = false;
-
-                        if (read < contentLen)
-                        {
-                            var temp = new byte[args.Count];
-
-                            respBody.Seek(0, SeekOrigin.Begin);
-                            int tmpRead = respBody.Read(temp, 0, temp.Length);
-                            respBody.Seek(0, SeekOrigin.Begin);
-
-                            Debug.Assert(tmpRead > 0);
-
-                            var readBytes = new byte[tmpRead];
-                            Buffer.BlockCopy(temp, 0, readBytes, 0, tmpRead);
-
-                            read += tmpRead;
-                            SendDataTo(stream, readBytes, read == contentLen);
-                        }
-                    };
-
-                await _next(context.Environment);
-
-                //Handle file not found case
-                if (response.StatusCode == StatusCode.Code404NotFound)
+                catch (Exception ex)
                 {
-                    WriteStatus(stream, response.StatusCode, response.StatusCode != StatusCode.Code200Ok, responseHeaders);
+                    EndResponse(stream, ex);
                 }
+            });
 
-                Http2Logger.LogDebug("Transfer end");
-            }
-            catch (Exception ex)
-            {   
-                EndResponse(stream, ex);;
-            }
         }
 
         /// <summary>
@@ -211,9 +116,11 @@ namespace Microsoft.Http2.Owin.Server.Adapters
         /// Ends the response in case of error.
         /// </summary>
         /// <param name="stream">The stream.</param>
-        /// <param name="ex">The catched exception.</param>
+        /// <param name="ex">The caught exception.</param>
         private void EndResponse(Http2Stream stream, Exception ex)
         {
+            Http2Logger.LogDebug("Error processing request:\r\n" + ex.ToString());
+            // TODO: What if the response has already started?
             WriteStatus(stream, StatusCode.Code500InternalServerError, true);
         }
 
@@ -224,41 +131,15 @@ namespace Microsoft.Http2.Owin.Server.Adapters
         /// <param name="statusCode">The status code.</param>
         /// <param name="final">if set to <c>true</c> then marks headers frame as final.</param>
         /// <param name="additionalHeaders">The additional headers.</param>
-        private void WriteStatus(Http2Stream stream, int statusCode, bool final, HeadersList additionalHeaders = null)
+        private void WriteStatus(Http2Stream stream, int statusCode, bool final, HeadersList headers = null)
         {
-            var headers = new HeadersList
-                {
-                    new KeyValuePair<string, string>(CommonHeaders.Status, statusCode.ToString()),
-                };
-
-            if (additionalHeaders != null)
+            if (headers == null)
             {
-                headers.AddRange(additionalHeaders);
+                headers = new HeadersList();
             }
+            headers.Add(new KeyValuePair<string, string>(CommonHeaders.Status, statusCode.ToString()));
 
             stream.WriteHeadersFrame(headers, final, true);
-        }
-
-        /// <summary>
-        /// Wraps data into data frames and sends it 
-        /// </summary>
-        /// <param name="stream">The stream.</param>
-        /// <param name="binaryData">The binary data.</param>
-        /// <param name="isLastChunk">if set to <c>true</c> then marks last data frame as final.</param>
-        private void SendDataTo(Http2Stream stream, byte[] binaryData, bool isLastChunk)
-        {
-            int i = 0;
-            do
-            {
-                int chunkSize = MathEx.Min(binaryData.Length - i, Constants.MaxFrameContentSize);
-
-                var chunk = new byte[chunkSize];
-                Buffer.BlockCopy(binaryData, i, chunk, 0, chunk.Length);
-
-                stream.WriteDataFrame(chunk, isLastChunk);
-
-                i += chunkSize;
-            } while (binaryData.Length > i);
         }
     }
 }

--- a/src/Microsoft.Http2.Owin.Server/Microsoft.Http2.Owin.Server.csproj
+++ b/src/Microsoft.Http2.Owin.Server/Microsoft.Http2.Owin.Server.csproj
@@ -51,6 +51,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Adapters\CommonOwinKeys.cs" />
+    <Compile Include="Adapters\Http2OwinMessageContext.cs" />
     <Compile Include="DictionaryExtensions.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Adapters\Http11Helper.cs" />

--- a/tests/Http2.Katana.Tests/Http2.Katana.Tests.csproj
+++ b/tests/Http2.Katana.Tests/Http2.Katana.Tests.csproj
@@ -116,6 +116,9 @@
     <Compile Include="..\..\src\Microsoft.Http2.Owin.Server\Adapters\Http11OwinMessageHandler.cs">
       <Link>Sources\Microsoft.Http2.Owin.Server\Adapters\Http11OwinMessageHandler.cs</Link>
     </Compile>
+    <Compile Include="..\..\src\Microsoft.Http2.Owin.Server\Adapters\Http2OwinMessageContext.cs">
+      <Link>Sources\Microsoft.Http2.Owin.Server\Adapters\Http2OwinMessageContext.cs</Link>
+    </Compile>
     <Compile Include="..\..\src\Microsoft.Http2.Owin.Server\Adapters\Http2OwinMessageHandler.cs">
       <Link>Sources\Microsoft.Http2.Owin.Server\Adapters\Http2OwinMessageHandler.cs</Link>
     </Compile>

--- a/tests/Http2.TestClient/Adapters/Http2ClientMessageHandler.cs
+++ b/tests/Http2.TestClient/Adapters/Http2ClientMessageHandler.cs
@@ -56,7 +56,7 @@ namespace Http2.TestClient.Adapters
                 if (!stream.EndStreamSent)
                 {
                     //send terminator
-                    stream.WriteDataFrame(new byte[0], true);
+                    stream.WriteDataFrame(new ArraySegment<byte>(new byte[0]), true);
                     Http2Logger.LogConsole("Terminator was sent");
                 }
                 _fileHelper.RemoveStream(path);


### PR DESCRIPTION
This change cleans up the response stream handling.  It works with the static file sample, but I haven't tested beyond that.
